### PR TITLE
Show question title in score endpoints

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -4058,6 +4058,7 @@ const docTemplate = `{
                 "judge_time",
                 "message",
                 "question_id",
+                "question_title",
                 "score"
             ],
             "properties": {
@@ -4076,6 +4077,10 @@ const docTemplate = `{
                 "question_id": {
                     "type": "integer",
                     "example": 1
+                },
+                "question_title": {
+                    "type": "string",
+                    "example": "Two Sum"
                 },
                 "score": {
                     "type": "number",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -4051,6 +4051,7 @@
                 "judge_time",
                 "message",
                 "question_id",
+                "question_title",
                 "score"
             ],
             "properties": {
@@ -4069,6 +4070,10 @@
                 "question_id": {
                     "type": "integer",
                     "example": 1
+                },
+                "question_title": {
+                    "type": "string",
+                    "example": "Two Sum"
                 },
                 "score": {
                     "type": "number",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -940,6 +940,9 @@ definitions:
       question_id:
         example: 1
         type: integer
+      question_title:
+        example: Two Sum
+        type: string
       score:
         example: 100
         type: number
@@ -948,6 +951,7 @@ definitions:
     - judge_time
     - message
     - question_id
+    - question_title
     - score
     type: object
   handlers.UpdateUserInfoDTO:


### PR DESCRIPTION
Enhance the `/api/score/all` and `/api/score/top` endpoints to include the question title in the response. This improves the clarity of the score data returned to users.