### PR TITLE
Migrate questions to private repositories in Gitea

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1464,7 +1464,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Take a question and create a repository in Gitea",
+                "description": "Take a question and migrate it to a private repository in Gitea (migrates the entire repo content to a new private repo)",
                 "consumes": [
                     "application/json"
                 ],
@@ -1474,7 +1474,7 @@ const docTemplate = `{
                 "tags": [
                     "Gitea"
                 ],
-                "summary": "Take a question and create a repository in Gitea",
+                "summary": "Take a question and migrate it to a private repository in Gitea",
                 "parameters": [
                     {
                         "type": "integer",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1457,7 +1457,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Take a question and create a repository in Gitea",
+                "description": "Take a question and migrate it to a private repository in Gitea (migrates the entire repo content to a new private repo)",
                 "consumes": [
                     "application/json"
                 ],
@@ -1467,7 +1467,7 @@
                 "tags": [
                     "Gitea"
                 ],
-                "summary": "Take a question and create a repository in Gitea",
+                "summary": "Take a question and migrate it to a private repository in Gitea",
                 "parameters": [
                     {
                         "type": "integer",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1777,7 +1777,8 @@ paths:
     post:
       consumes:
       - application/json
-      description: Take a question and create a repository in Gitea
+      description: Take a question and migrate it to a private repository in Gitea
+        (migrates the entire repo content to a new private repo)
       parameters:
       - description: Question ID
         in: path
@@ -1801,7 +1802,7 @@ paths:
           description: Service Unavailable
       security:
       - BearerAuth: []
-      summary: Take a question and create a repository in Gitea
+      summary: Take a question and migrate it to a private repository in Gitea
       tags:
       - Gitea
   /api/gitea/admin/user/bulk:


### PR DESCRIPTION
Update the API to migrate questions to private repositories in Gitea, including changes to descriptions and summaries for clarity. Adjust the repository creation logic to ensure the migration process is handled correctly.