### PR TITLE
Add rate limiting for forget password requests

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -3001,6 +3001,9 @@ const docTemplate = `{
                     "404": {
                         "description": "Not Found"
                     },
+                    "429": {
+                        "description": "Too Many Requests"
+                    },
                     "503": {
                         "description": "Service Unavailable"
                     }
@@ -4887,6 +4890,9 @@ const docTemplate = `{
                 },
                 "enable": {
                     "type": "boolean"
+                },
+                "forget_password_request_time": {
+                    "type": "string"
                 },
                 "gitea_token": {
                     "type": "string"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -2994,6 +2994,9 @@
                     "404": {
                         "description": "Not Found"
                     },
+                    "429": {
+                        "description": "Too Many Requests"
+                    },
                     "503": {
                         "description": "Service Unavailable"
                     }
@@ -4880,6 +4883,9 @@
                 },
                 "enable": {
                     "type": "boolean"
+                },
+                "forget_password_request_time": {
+                    "type": "string"
                 },
                 "gitea_token": {
                     "type": "string"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1195,6 +1195,8 @@ definitions:
         type: string
       enable:
         type: boolean
+      forget_password_request_time:
+        type: string
       gitea_token:
         type: string
       id:
@@ -3046,6 +3048,8 @@ paths:
           description: Unauthorized
         "404":
           description: Not Found
+        "429":
+          description: Too Many Requests
         "503":
           description: Service Unavailable
       summary: Forget password

--- a/models/user.go
+++ b/models/user.go
@@ -1,14 +1,17 @@
 package models
 
+import "time"
+
 type User struct {
-	ID            uint   `gorm:"primaryKey" json:"id"`
-	UserName      string `gorm:"size:100;not null" json:"user_name"`
-	Enable        bool   `gorm:"default:true;not null" json:"enable"`
-	Email         string `gorm:"size:450;not null" json:"email"`
-	IsPublic      bool   `gorm:"default:true;not null" json:"is_public"`
-	GiteaToken    string `gorm:"size:450" json:"gitea_token"`
-	RefreshToken  string `gorm:"size:1000" json:"refresh_token"`
-	Nonce         string `gorm:"size:100" json:"nonce"`
-	IsAdmin       bool   `gorm:"default:false;not null" json:"is_admin"`
-	ResetPassword bool   `gorm:"default:false;not null" json:"reset_password"`
+	ID                        uint      `gorm:"primaryKey" json:"id"`
+	UserName                  string    `gorm:"size:100;not null" json:"user_name"`
+	Enable                    bool      `gorm:"default:true;not null" json:"enable"`
+	Email                     string    `gorm:"size:450;not null" json:"email"`
+	IsPublic                  bool      `gorm:"default:true;not null" json:"is_public"`
+	GiteaToken                string    `gorm:"size:450" json:"gitea_token"`
+	RefreshToken              string    `gorm:"size:1000" json:"refresh_token"`
+	Nonce                     string    `gorm:"size:100" json:"nonce"`
+	IsAdmin                   bool      `gorm:"default:false;not null" json:"is_admin"`
+	ResetPassword             bool      `gorm:"default:false;not null" json:"reset_password"`
+	ForgetPasswordRequestTime time.Time `json:"forget_password_request_time"`
 }


### PR DESCRIPTION
Implement a mechanism to limit the frequency of forget password requests, preventing multiple submissions within a short time frame. Update the API documentation to reflect the new status code for too many requests.