### PR TITLE
Add SQL indexes and fix refresh token query

### DIFF
--- a/handlers/auth.go
+++ b/handlers/auth.go
@@ -247,7 +247,7 @@ func RefreshToken(c *gin.Context) {
 
 	// Check if user exists and refresh token matches
 	var user models.User
-	if err := db.Where("id = ? AND refresh_token = ?", claims.UserID, refreshToken, true).First(&user).Error; err != nil {
+	if err := db.Where("id = ? AND refresh_token = ?", claims.UserID, refreshToken).First(&user).Error; err != nil {
 		c.JSON(401, ResponseHTTP{
 			Success: false,
 			Message: "Invalid refresh token",

--- a/models/userQuestionRelation.go
+++ b/models/userQuestionRelation.go
@@ -2,9 +2,9 @@ package models
 
 type UserQuestionRelation struct {
 	ID             uint     `gorm:"primaryKey" json:"id"`
-	UserID         uint     `gorm:"not null" json:"user_id"`
+	UserID         uint     `gorm:"not null;index:idx_uqr_question_user" json:"user_id"`
 	User           User     `gorm:"constraint:OnUpdate:CASCADE,OnDelete:SET NULL;" json:"user"`
-	QuestionID     uint     `gorm:"not null" json:"question_id"`
+	QuestionID     uint     `gorm:"not null;index:idx_uqr_question_user" json:"question_id"`
 	Question       Question `gorm:"constraint:OnUpdate:CASCADE,OnDelete:SET NULL;" json:"question"`
 	GitUserRepoURL string   `gorm:"size:150;not null" json:"git_user_repo_url"`
 }

--- a/models/userQuestionTable.go
+++ b/models/userQuestionTable.go
@@ -4,11 +4,11 @@ import "time"
 
 type UserQuestionTable struct {
 	ID        uint                 `gorm:"primaryKey" json:"id"`
-	UQRID     uint                 `gorm:"not null" json:"uqr_id"`
+	UQRID     uint                 `gorm:"not null;index:idx_uqt_uqr_score_created,priority:1" json:"uqr_id"`
 	UQR       UserQuestionRelation `gorm:"constraint:OnUpdate:CASCADE,OnDelete:SET NULL;" json:"uqr"`
-	Score     float64              `gorm:"not null" json:"score"`
+	Score     float64              `gorm:"not null;index:idx_uqt_uqr_score_created,priority:2" json:"score"`
 	JudgeTime time.Time            `gorm:"not null;default:CURRENT_TIMESTAMP" json:"judge_time" example:"2006-01-02T15:04:05Z07:00" time_format:"RFC3339"`
 	Message   string               `gorm:"not null" json:"message"`
 	Commit    string               `gorm:"size:150;not null;default:''" json:"commit"`
-	CreatedAt time.Time            `gorm:"autoCreateTime" json:"created_at"`
+	CreatedAt time.Time            `gorm:"autoCreateTime;index:idx_uqt_uqr_score_created,priority:3" json:"created_at"`
 }


### PR DESCRIPTION
Introduce SQL indexes for improved query performance and correct the refresh token validation query by removing an unnecessary parameter.