### PR TITLE
Add release build workflow for GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Build and Release
+
+on:
+  push:
+    tags:
+      - "v*"   # 例如 v1.0.0 才會觸發
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.23.5"
+
+      - name: Build binary
+        run: |
+          mkdir -p dist
+          GOOS=linux GOARCH=amd64 go build -o dist/server-linux-amd64
+          GOOS=linux GOARCH=arm64 go build -o dist/server-linux-arm64
+          GOOS=linux GOARCH=amd64 go build -o dist/server-sandbox-linux-amd64 ./cmd/sandbox-server
+          GOOS=linux GOARCH=arm64 go build -o dist/server-sandbox-linux-arm64 ./cmd/sandbox-server
+
+      - name: Upload Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Introduce a GitHub Actions workflow to automate the build and release process for the project. This includes building binaries for different architectures and uploading them as release assets.