### PR TITLE
Admin bypass for question retrieval

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -2112,67 +2112,6 @@ const docTemplate = `{
                 }
             }
         },
-        "/api/questions/user/{ID}/question": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Retrieve a specific question associated with a user by its Question ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Question"
-                ],
-                "summary": "Get a user's question by Question ID",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "ID of the Question to get",
-                        "name": "ID",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/handlers.ResponseHTTP"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "$ref": "#/definitions/handlers.GetUserQuestionResponseData"
-                                        }
-                                    }
-                                }
-                            ]
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request"
-                    },
-                    "401": {
-                        "description": "Unauthorized"
-                    },
-                    "404": {
-                        "description": "Not Found"
-                    },
-                    "503": {
-                        "description": "Service Unavailable"
-                    }
-                }
-            }
-        },
         "/api/questions/{ID}/question": {
             "get": {
                 "description": "Retrieve only public questions",
@@ -4259,37 +4198,6 @@ const docTemplate = `{
                 },
                 "user_name": {
                     "type": "string"
-                }
-            }
-        },
-        "handlers.GetUserQuestionResponseData": {
-            "type": "object",
-            "required": [
-                "description",
-                "git_repo_url",
-                "parent_git_repo_url",
-                "readme",
-                "title",
-                "uqr_id"
-            ],
-            "properties": {
-                "description": {
-                    "type": "string"
-                },
-                "git_repo_url": {
-                    "type": "string"
-                },
-                "parent_git_repo_url": {
-                    "type": "string"
-                },
-                "readme": {
-                    "type": "string"
-                },
-                "title": {
-                    "type": "string"
-                },
-                "uqr_id": {
-                    "type": "integer"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -2105,67 +2105,6 @@
                 }
             }
         },
-        "/api/questions/user/{ID}/question": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Retrieve a specific question associated with a user by its Question ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Question"
-                ],
-                "summary": "Get a user's question by Question ID",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "ID of the Question to get",
-                        "name": "ID",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/handlers.ResponseHTTP"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "$ref": "#/definitions/handlers.GetUserQuestionResponseData"
-                                        }
-                                    }
-                                }
-                            ]
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request"
-                    },
-                    "401": {
-                        "description": "Unauthorized"
-                    },
-                    "404": {
-                        "description": "Not Found"
-                    },
-                    "503": {
-                        "description": "Service Unavailable"
-                    }
-                }
-            }
-        },
         "/api/questions/{ID}/question": {
             "get": {
                 "description": "Retrieve only public questions",
@@ -4252,37 +4191,6 @@
                 },
                 "user_name": {
                     "type": "string"
-                }
-            }
-        },
-        "handlers.GetUserQuestionResponseData": {
-            "type": "object",
-            "required": [
-                "description",
-                "git_repo_url",
-                "parent_git_repo_url",
-                "readme",
-                "title",
-                "uqr_id"
-            ],
-            "properties": {
-                "description": {
-                    "type": "string"
-                },
-                "git_repo_url": {
-                    "type": "string"
-                },
-                "parent_git_repo_url": {
-                    "type": "string"
-                },
-                "readme": {
-                    "type": "string"
-                },
-                "title": {
-                    "type": "string"
-                },
-                "uqr_id": {
-                    "type": "integer"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -791,28 +791,6 @@ definitions:
       user_name:
         type: string
     type: object
-  handlers.GetUserQuestionResponseData:
-    properties:
-      description:
-        type: string
-      git_repo_url:
-        type: string
-      parent_git_repo_url:
-        type: string
-      readme:
-        type: string
-      title:
-        type: string
-      uqr_id:
-        type: integer
-    required:
-    - description
-    - git_repo_url
-    - parent_git_repo_url
-    - readme
-    - title
-    - uqr_id
-    type: object
   handlers.GetUsersQuestionsResponseData:
     properties:
       question:
@@ -2537,43 +2515,6 @@ paths:
       security:
       - BearerAuth: []
       summary: Get a list of questions by user
-      tags:
-      - Question
-  /api/questions/user/{ID}/question:
-    get:
-      consumes:
-      - application/json
-      description: Retrieve a specific question associated with a user by its Question
-        ID
-      parameters:
-      - description: ID of the Question to get
-        in: path
-        name: ID
-        required: true
-        type: integer
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            allOf:
-            - $ref: '#/definitions/handlers.ResponseHTTP'
-            - properties:
-                data:
-                  $ref: '#/definitions/handlers.GetUserQuestionResponseData'
-              type: object
-        "400":
-          description: Bad Request
-        "401":
-          description: Unauthorized
-        "404":
-          description: Not Found
-        "503":
-          description: Service Unavailable
-      security:
-      - BearerAuth: []
-      summary: Get a user's question by Question ID
       tags:
       - Question
   /api/sandbox/admin/sandbox_cmd:

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -198,14 +198,13 @@ func RegisterRoutes(r *gin.Engine) {
 
 		// Questions routes
 		api.GET("/questions", AuthMiddleware(false), handlers.GetQuestionList)
-		api.GET("/questions/:ID/question", handlers.GetQuestionByID)
+		api.GET("/questions/:ID/question", AuthMiddleware(false), handlers.GetQuestionByID)
 		api.PATCH("/questions/admin/:ID/question", AuthMiddleware(), handlers.PatchQuestion)
 		api.DELETE("/questions/admin/:ID/question", AuthMiddleware(), handlers.DeleteQuestion)
 		api.POST("/questions/admin/question", AuthMiddleware(), handlers.AddQuestion)
 		api.GET("/questions/admin/:ID/question_limit", AuthMiddleware(), handlers.GetQuestionLimitByID)
 		api.GET("/questions/admin/:ID/scripts", AuthMiddleware(), handlers.GetQuestionScripts)
 		api.GET("/questions/user", AuthMiddleware(), handlers.GetUsersQuestions)
-		api.GET("/questions/user/:ID/question", AuthMiddleware(), handlers.GetUserQuestionByID)
 
 		// Score routes
 		api.GET("/score", AuthMiddleware(), handlers.GetScoreByRepo)


### PR DESCRIPTION
Implement an admin bypass for the `GetQuestionByID` & `GetQuestionLimitByID` route, enhancing access control for admin users. Remove the user-specific question retrieval endpoint(`GetUserQuestionByID` route) from the API documentation and definitions.