### PR TITLE
Check question active time before processing

### DIFF
--- a/handlers/score.go
+++ b/handlers/score.go
@@ -400,6 +400,14 @@ func ReScoreUserQuestion(c *gin.Context) {
 		})
 		return
 	}
+	// Check question active time
+	if question.StartTime.After(time.Now().UTC()) || question.EndTime.Before(time.Now().UTC()) {
+		c.JSON(410, ResponseHTTP{
+			Success: false,
+			Message: "Question is not in active time range",
+		})
+		return
+	}
 
 	var uqr models.UserQuestionRelation
 	if err := db.Model(&models.UserQuestionRelation{}).


### PR DESCRIPTION
Implement a check to ensure that questions are only processed if they are within the active time range. Return a 410 status code if the question is not active.