### PR TITLE
Update exam time and related questions' time

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -565,6 +565,11 @@ const docTemplate = `{
         },
         "/api/exams": {
             "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
                 "description": "Retrieve a list of all exams",
                 "produces": [
                     "application/json"
@@ -749,7 +754,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.Exam"
+                            "$ref": "#/definitions/handlers.UpdateExamRequest"
                         }
                     }
                 ],
@@ -765,7 +770,7 @@ const docTemplate = `{
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/models.Exam"
+                                            "$ref": "#/definitions/handlers.UpdateExamRequest"
                                         }
                                     }
                                 }
@@ -955,6 +960,11 @@ const docTemplate = `{
         },
         "/api/exams/{id}/exam": {
             "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
                 "description": "Retrieve basic information about an exam, including title, description, start and end times",
                 "produces": [
                     "application/json"
@@ -4668,6 +4678,28 @@ const docTemplate = `{
                 "score": {
                     "type": "number",
                     "example": 100
+                }
+            }
+        },
+        "handlers.UpdateExamRequest": {
+            "type": "object",
+            "required": [
+                "title"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "end_time": {
+                    "type": "string",
+                    "example": "2006-01-02T15:04:05Z"
+                },
+                "start_time": {
+                    "type": "string",
+                    "example": "2006-01-02T15:04:05Z"
+                },
+                "title": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -558,6 +558,11 @@
         },
         "/api/exams": {
             "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
                 "description": "Retrieve a list of all exams",
                 "produces": [
                     "application/json"
@@ -742,7 +747,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.Exam"
+                            "$ref": "#/definitions/handlers.UpdateExamRequest"
                         }
                     }
                 ],
@@ -758,7 +763,7 @@
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/models.Exam"
+                                            "$ref": "#/definitions/handlers.UpdateExamRequest"
                                         }
                                     }
                                 }
@@ -948,6 +953,11 @@
         },
         "/api/exams/{id}/exam": {
             "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
                 "description": "Retrieve basic information about an exam, including title, description, start and end times",
                 "produces": [
                     "application/json"
@@ -4661,6 +4671,28 @@
                 "score": {
                     "type": "number",
                     "example": 100
+                }
+            }
+        },
+        "handlers.UpdateExamRequest": {
+            "type": "object",
+            "required": [
+                "title"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "end_time": {
+                    "type": "string",
+                    "example": "2006-01-02T15:04:05Z"
+                },
+                "start_time": {
+                    "type": "string",
+                    "example": "2006-01-02T15:04:05Z"
+                },
+                "title": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1093,6 +1093,21 @@ definitions:
     - question_title
     - score
     type: object
+  handlers.UpdateExamRequest:
+    properties:
+      description:
+        type: string
+      end_time:
+        example: "2006-01-02T15:04:05Z"
+        type: string
+      start_time:
+        example: "2006-01-02T15:04:05Z"
+        type: string
+      title:
+        type: string
+    required:
+    - title
+    type: object
   handlers.UpdateUserInfoDTO:
     properties:
       enable:
@@ -1597,6 +1612,8 @@ paths:
           description: Internal Server Error
           schema:
             $ref: '#/definitions/handlers.ResponseHTTP'
+      security:
+      - BearerAuth: []
       summary: List all exams
       tags:
       - Exam
@@ -1630,6 +1647,8 @@ paths:
           description: Internal Server Error
           schema:
             $ref: '#/definitions/handlers.ResponseHTTP'
+      security:
+      - BearerAuth: []
       summary: Get basic information about an exam
       tags:
       - Exam
@@ -1876,7 +1895,7 @@ paths:
         name: exam
         required: true
         schema:
-          $ref: '#/definitions/models.Exam'
+          $ref: '#/definitions/handlers.UpdateExamRequest'
       produces:
       - application/json
       responses:
@@ -1887,7 +1906,7 @@ paths:
             - $ref: '#/definitions/handlers.ResponseHTTP'
             - properties:
                 data:
-                  $ref: '#/definitions/models.Exam'
+                  $ref: '#/definitions/handlers.UpdateExamRequest'
               type: object
         "400":
           description: Bad Request


### PR DESCRIPTION
Enhance the exam update functionality by allowing updates to the exam's start and end times, and ensure that related exam questions' times are also updated accordingly. Introduce a new request structure for updating exam details.